### PR TITLE
Add textarea, codearea control knobs

### DIFF
--- a/components/knobs-component/index.jsx
+++ b/components/knobs-component/index.jsx
@@ -58,7 +58,7 @@ function renderControls(values, setValues, indentLevel = 0) {
       )
     }
 
-    if (v.control === 'html' || v.control === 'textarea') {
+    if (v.control === 'codearea' || v.control === 'textarea') {
       control = (
         <textarea
           className={s[v.control]}

--- a/components/knobs-component/index.jsx
+++ b/components/knobs-component/index.jsx
@@ -58,6 +58,19 @@ function renderControls(values, setValues, indentLevel = 0) {
       )
     }
 
+    if (v.control === 'textarea') {
+      control = (
+        <textarea
+          className={s.input}
+          value={v.value || v.defaultValue}
+          onChange={e => {
+            valuesCopy[k].value = e.target.value
+            setValues(valuesCopy)
+          }}
+        />
+      )
+    }
+
     if (v.control === 'select') {
       control = (
         <select

--- a/components/knobs-component/index.jsx
+++ b/components/knobs-component/index.jsx
@@ -58,10 +58,10 @@ function renderControls(values, setValues, indentLevel = 0) {
       )
     }
 
-    if (v.control === 'textarea') {
+    if (v.control === 'html' || v.control === 'textarea') {
       control = (
         <textarea
-          className={s.input}
+          className={s[v.control]}
           value={v.value || v.defaultValue}
           onChange={({ target }) => {
             valuesCopy[k].value = target.value
@@ -69,6 +69,7 @@ function renderControls(values, setValues, indentLevel = 0) {
             if (target) autosize(target)
           }}
           ref={target => target && autosize(target)}
+          spellCheck={v.control === 'textarea'}
         />
       )
     }

--- a/components/knobs-component/index.jsx
+++ b/components/knobs-component/index.jsx
@@ -63,10 +63,12 @@ function renderControls(values, setValues, indentLevel = 0) {
         <textarea
           className={s.input}
           value={v.value || v.defaultValue}
-          onChange={e => {
-            valuesCopy[k].value = e.target.value
+          onChange={({ target }) => {
+            valuesCopy[k].value = target.value
             setValues(valuesCopy)
+            if (target) autosize(target)
           }}
+          ref={target => target && autosize(target)}
         />
       )
     }
@@ -137,6 +139,13 @@ function renderControls(values, setValues, indentLevel = 0) {
       </div>
     )
   })
+}
+
+function autosize(target) {
+  const { style, style: { height } } = target
+  style.height = style.minHeight = 'inherit'
+  style.minHeight = `${target.scrollHeight}px`
+  style.height = height
 }
 
 function knobsToProps(knobs) {

--- a/components/knobs-component/style.module.css
+++ b/components/knobs-component/style.module.css
@@ -114,6 +114,7 @@
 }
 
 .textarea {
-  composes: input;
+	composes: input;
+	resize: vertical;
   width: 100%;
 }

--- a/components/knobs-component/style.module.css
+++ b/components/knobs-component/style.module.css
@@ -113,7 +113,7 @@
   outline: 0;
 }
 
-.html {
+.codearea {
   composes: input;
   font-family: monospace;
   font-size: 14px;

--- a/components/knobs-component/style.module.css
+++ b/components/knobs-component/style.module.css
@@ -113,8 +113,15 @@
   outline: 0;
 }
 
+.html {
+  composes: input;
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 22px;
+  width: 100%;
+}
+
 .textarea {
-	composes: input;
-	resize: vertical;
+  composes: input;
   width: 100%;
 }

--- a/components/knobs-component/style.module.css
+++ b/components/knobs-component/style.module.css
@@ -112,3 +112,8 @@
   border-color: #9bced3;
   outline: 0;
 }
+
+.textarea {
+  composes: input;
+  width: 100%;
+}


### PR DESCRIPTION
This change adds support for a `<textarea>` control to the `KnobsComponent` as `textarea` and `codearea`. This control would allow users to adjust values with large blocks of text or code, especially those with line breaks.

The `<textarea>` is styled to be full width, sized to fit its contents, and further expandable vertically. The `codearea` variant additionally disables spell checking and styles text to use a monospace font.