### PR TITLE
Better support for array and other more complex props

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Control types currently available are:
 - `text`
 - `select` -- requires `options` to be set
 - `checkbox`
+- `json` - freeform input for any js object, not recommended
 
 TODO: screenshot here
 
@@ -170,7 +171,8 @@ The `props.json5` file does have an expected object structure, which is detailed
     required: Boolean, // is it a required prop?
     control: String, // for knobs, see <KnobsComponent> docs above
     options: []String, // if there are only a specific set of values, detail them here
-    defaultValue: String // for knobs, the starting value
+    defaultValue: String, // for knobs, the starting value
+    itemType: String // for array props, a way to freeform document what type(s) it expects its items to have
   }
 }
 ```

--- a/components/knobs-component/index.jsx
+++ b/components/knobs-component/index.jsx
@@ -14,7 +14,7 @@ export default function createKnobsComponent(scope) {
     const [values, setValues] = useState(knobs)
 
     // if there's url state and it applies to this element, restore it
-    useRestoreUrlState(qs => {
+    useRestoreUrlState((qs) => {
       if (qs.id == id) {
         setValues(qs.values)
         scrollToElement(id)
@@ -40,7 +40,7 @@ export default function createKnobsComponent(scope) {
 }
 
 function renderControls(values, setValues, indentLevel = 0) {
-  return Object.keys(values).map(k => {
+  return Object.keys(values).map((k) => {
     const valuesCopy = JSON.parse(JSON.stringify(values))
     const v = values[k]
     let control
@@ -50,7 +50,7 @@ function renderControls(values, setValues, indentLevel = 0) {
         <input
           className={s.input}
           value={v.value || v.defaultValue}
-          onChange={e => {
+          onChange={(e) => {
             valuesCopy[k].value = e.target.value
             setValues(valuesCopy)
           }}
@@ -63,13 +63,13 @@ function renderControls(values, setValues, indentLevel = 0) {
         <select
           className={s.select}
           value={v.value || v.defaultValue}
-          onChange={e => {
+          onChange={(e) => {
             valuesCopy[k].value = e.target.value
             setValues(valuesCopy)
           }}
         >
           <option value={null}>Select an option...</option>
-          {v.options.map(opt => (
+          {v.options.map((opt) => (
             <option key={opt} value={opt}>
               {opt}
             </option>
@@ -81,11 +81,24 @@ function renderControls(values, setValues, indentLevel = 0) {
     if (v.control === 'checkbox') {
       control = (
         <input
-          type='checkbox'
+          type="checkbox"
           className={s.checkbox}
           checked={v.value || v.defaultValue}
-          onChange={e => {
+          onChange={(e) => {
             valuesCopy[k].value = e.target.checked
+            setValues(valuesCopy)
+          }}
+        />
+      )
+    }
+
+    if (v.control === 'json') {
+      control = (
+        <textarea
+          className={s.textarea}
+          value={JSON.stringify(v.value || v.defaultValue, null, 2)}
+          onChange={(e) => {
+            valuesCopy[k].value = JSON.parse(e.target.value)
             setValues(valuesCopy)
           }}
         />
@@ -102,7 +115,7 @@ function renderControls(values, setValues, indentLevel = 0) {
         <label>
           {k}
           {v.required ? (
-            <span className={s.requiredStar} title='required'>
+            <span className={s.requiredStar} title="required">
               *
             </span>
           ) : (
@@ -114,7 +127,7 @@ function renderControls(values, setValues, indentLevel = 0) {
         {!v.control
           ? renderControls(
               v,
-              subtreeValue => {
+              (subtreeValue) => {
                 valuesCopy[k] = subtreeValue
                 setValues(valuesCopy)
               },

--- a/components/knobs-component/style.module.css
+++ b/components/knobs-component/style.module.css
@@ -94,7 +94,8 @@
   font-weight: normal;
 }
 
-.input {
+.input,
+.textarea {
   border: 1px solid #ccc;
   border-radius: 3px;
   font-weight: 700;
@@ -104,11 +105,18 @@
   transition: border-color 0.2s ease;
 }
 
-.input:hover {
+.input:hover,
+.textarea:hover {
   border-color: #aaa;
 }
 
-.input:focus {
+.input:focus,
+.textarea:focus {
   border-color: #9bced3;
   outline: 0;
+}
+
+.textarea {
+  width: 400px;
+  min-height: 100px;
 }

--- a/components/props-table/index.jsx
+++ b/components/props-table/index.jsx
@@ -7,7 +7,7 @@ const permittedKeys = [
   'control',
   'options',
   'defaultValue',
-  'required'
+  'required',
 ]
 
 export default function PropsTable({ props }) {
@@ -33,7 +33,7 @@ function renderRows(props, prefix) {
     // we know which standard keys are expected -- when there are non-standard keys, this is an indication that
     // we likely have a nested prop
     const nonStandardKeys = Object.keys(props[key]).filter(
-      k => !permittedKeys.includes(k)
+      (k) => !permittedKeys.includes(k)
     )
     const hasNestedProps = !props[key].control && nonStandardKeys.length > 0
 
@@ -54,10 +54,10 @@ function renderRows(props, prefix) {
       // first let's remove the permitted keys since we already rendered these, to leave only
       // the top-level nested props
       const nestedPropsCopy = JSON.parse(JSON.stringify(props[key]))
-      permittedKeys.map(k => delete nestedPropsCopy[k])
+      permittedKeys.map((k) => delete nestedPropsCopy[k])
 
       // now we recurse with the rest of the props
-      res.push(renderRows(nestedPropsCopy, key))
+      res.push(renderRows(nestedPropsCopy, { key, value }))
     }
   }
 
@@ -69,7 +69,14 @@ function renderRow(key, value, hasNestedProps, prefix) {
     <tr key={key}>
       <td>
         <code>
-          {prefix ? <span className={s.prefix}>{prefix}.</span> : ''}
+          {prefix ? (
+            <span className={s.prefix}>
+              {prefix.key}
+              {prefix.value.type.toLowerCase() === 'array' ? '[n].' : '.'}
+            </span>
+          ) : (
+            ''
+          )}
           {key}
           {value.required ? <span className={s.required}>*</span> : ''}
           <div className={s.type}>{value.type}</div>
@@ -88,9 +95,14 @@ function renderRow(key, value, hasNestedProps, prefix) {
             ))}
           </div>
         )}
-        {hasNestedProps && (
+        {hasNestedProps && value.type.toLowerCase() === 'object' && (
           <div className={s.containsNested}>
             Contains nested props, see below:
+          </div>
+        )}
+        {hasNestedProps && value.type.toLowerCase() === 'array' && (
+          <div className={s.containsNested}>
+            Each array item is an object with the props below:
           </div>
         )}
       </td>

--- a/components/props-table/index.jsx
+++ b/components/props-table/index.jsx
@@ -57,7 +57,7 @@ function renderRows(props, prefix) {
       permittedKeys.map((k) => delete nestedPropsCopy[k])
 
       // now we recurse with the rest of the props
-      res.push(renderRows(nestedPropsCopy, { key, value }))
+      res.push(renderRows(nestedPropsCopy, key))
     }
   }
 
@@ -69,14 +69,7 @@ function renderRow(key, value, hasNestedProps, prefix) {
     <tr key={key}>
       <td>
         <code>
-          {prefix ? (
-            <span className={s.prefix}>
-              {prefix.key}
-              {prefix.value.type.toLowerCase() === 'array' ? '[n].' : '.'}
-            </span>
-          ) : (
-            ''
-          )}
+          {prefix ? <span className={s.prefix}>{prefix}.</span> : ''}
           {key}
           {value.required ? <span className={s.required}>*</span> : ''}
           <div className={s.type}>{value.type}</div>
@@ -95,14 +88,15 @@ function renderRow(key, value, hasNestedProps, prefix) {
             ))}
           </div>
         )}
-        {hasNestedProps && value.type.toLowerCase() === 'object' && (
-          <div className={s.containsNested}>
-            Contains nested props, see below:
+        {value.itemType && (
+          <div className={s.options}>
+            <strong>Item Type: </strong>
+            <code>{value.itemType}</code>
           </div>
         )}
-        {hasNestedProps && value.type.toLowerCase() === 'array' && (
+        {hasNestedProps && (
           <div className={s.containsNested}>
-            Each array item is an object with the props below:
+            Contains nested props, see below:
           </div>
         )}
       </td>


### PR DESCRIPTION
This PR adds two new things:

### JSON Control Type
This new type will render the default value into a textarea as json if using the knobs component. This will accept more complex props, and allow basic, if awkward, editing in the knobs interface. This is kind of a "last resort" rendering option which is not recommended. **Example:**

  <img width="1058" alt="Component Library 2020-09-15 at 3 43 42 PM" src="https://user-images.githubusercontent.com/556932/93257099-5c93b700-f76a-11ea-9b62-6884ce4d2fff.png">

### `itemType` key in `props.json5`
This new option for the `props.json5` file will add an annotation to the props table intended for array props that allows the author to describe the type(s) accepted by the array in a freeform manner. **Example:**

  ![](https://p176.p0.n0.cdn.getcloudapp.com/items/P8ub4gvN/Screen%20Shot%202020-09-15%20at%203.42.54%20PM.png?v=f5b73bc894a1316c97cf3e7bff1eb4cf)