### PR TITLE
Improve Properties Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ Assuming that you're in a `docs.mdx` file with a `componentName` of `Button`, th
 
 This is a very simple component - it just expects a single child, as a string, which it renders into the code editor.
 
+If you have a need for components other than the component being documented in your example, these can be provided through a `components` prop, as such:
+
+```jsx
+<LiveComponent
+  components={{
+    SomeContent: () => <p>content yay</p>,
+  }}
+>{`<Button url='http://example.com'><SomeContent /></Button>`}</LiveComponent>
+```
+
+This is best used when you want to represent another component in your example, but the actual implementation of that component would distract from the point trying to be made in the example.
+
 TODO: screenshot here
 
 #### `<KnobsComponent>`
@@ -91,16 +103,16 @@ As usual, a usage example upfront:
     text: {
       control: {
         type: 'text',
-        value: 'http://example.com'
+        value: 'http://example.com',
       },
       required: true,
     },
     disabled: {
-      control: { type: 'checkbox' }
+      control: { type: 'checkbox' },
     },
     theme: {
       control: { type: 'select' },
-      options: ['foo', 'bar']
+      options: ['foo', 'bar'],
     },
   }}
 />
@@ -118,7 +130,7 @@ Nested props are supported as well, to infinite depth. For example, a nested `th
     theme: {
       color: {
         control: { type: 'select' },
-        options: ['red', 'blue']
+        options: ['red', 'blue'],
       },
       style: {
         control: { type: 'select' },
@@ -193,7 +205,7 @@ interface Properties = {
 
 As with other components, props can be nested here as well. There are a few specific caveats with the `control` value in nested properties though:
 
-- 
+-
 
 Let's lock this all in with a real example of a simple `props.js` file:
 
@@ -204,7 +216,7 @@ module.exports = {
     description: 'The headline displayed above the content',
     required: true,
     testValue: 'Test Headline',
-    control: { type: 'text' }
+    control: { type: 'text' },
   },
   data: {
     type: 'object',
@@ -219,28 +231,34 @@ module.exports = {
       },
       logos: {
         type: 'array',
-        description: 'company logos to be displayed and show how cool your product is',
+        description:
+          'company logos to be displayed and show how cool your product is',
         control: { type: 'json' },
-        properties: [{
-          type: 'string',
-          description: 'a string specifying a known company slug for which the logo will be displayed'
-        }, {
-          type: 'object',
-          description: 'if its not a known company, a custom object containing the necessary info to render',
-          properties: {
-            name: {
-              type: 'string',
-              description: 'the company name'
+        properties: [
+          {
+            type: 'string',
+            description:
+              'a string specifying a known company slug for which the logo will be displayed',
+          },
+          {
+            type: 'object',
+            description:
+              'if its not a known company, a custom object containing the necessary info to render',
+            properties: {
+              name: {
+                type: 'string',
+                description: 'the company name',
+              },
+              logo: {
+                type: 'string',
+                description: 'url of the company logo to be displayed',
+              },
             },
-            logo: {
-              type: 'string',
-              description: 'url of the company logo to be displayed'
-            }
-          }
-        }]
-      }
-    }
-  }
+          },
+        ],
+      },
+    },
+  },
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ If you have a need for components other than the component being documented in y
 
 This is best used when you want to represent another component in your example, but the actual implementation of that component would distract from the point trying to be made in the example.
 
+There's one more useful prop to `LiveComponent` -- `collapsed`. If this prop is set to `true`, the code editor will be collapsed by default - when clicked it will expand. This is useful for examples that contain a lot of code - you can collapse the editor by default to make it easier for users to scroll through examples, then expand the code editor only when they want to see/edit the source code. It is `true` by default.
+
 TODO: screenshot here
 
 #### `<KnobsComponent>`

--- a/README.md
+++ b/README.md
@@ -159,25 +159,25 @@ TODO: screenshot here
 
 An additional, optional convention is to define your component's props in a separate file. You may ask yourself, "but why can't I use typescript, or jsdocs in my component, or PropTypes?!" The answer in this case is because octavo does not want to impose anything upon the way that you choose to build your components, so instead it offers an optional manner of detailing your props outside of your actual component.
 
-If you include a `props.json5` file in the folder with your component, it will be picked up, parsed, and injected into your `docs.mdx` file as `componentProps`. You can then pass it into the `<PropsTable>` and/or `<KnobsComponent>` components, either fully, or splitting out individual props or sets of props, to save yourself lots of repetition and make your docs file much more terse.
+If you include a `props.js` file in the folder with your component, it will be picked up, parsed, and injected into your `docs.mdx` file as `componentProps`. You can then pass it into the `<PropsTable>` and/or `<KnobsComponent>` components, either fully, or splitting out individual props or sets of props, to save yourself lots of repetition and make your docs file much more terse.
 
-The `props.json5` file does have an expected object structure, which is detailed below in psuedo-typescript style:
+The `props.js` file does have an expected object structure, which is detailed below in psuedo-typescript style:
 
 ```typescript
-{
+interface Properties = {
   propName: {
-    type: String, // write out the type you expect however you please
-    description: String, // a short description of your prop
-    required: Boolean, // is it a required prop?
-    control: String, // for knobs, see <KnobsComponent> docs above
-    options: []String, // if there are only a specific set of values, detail them here
-    defaultValue: String, // for knobs, the starting value
-    itemType: String // for array props, a way to freeform document what type(s) it expects its items to have
+    type: string, // write out the type you expect however you please
+    description: string, // a short description of your prop
+    required: boolean, // is it a required prop?
+    control: string, // for knobs, see <KnobsComponent> docs above
+    options: []string, // if there are only a specific set of values, detail them here
+    defaultValue: string, // for knobs, the starting value
+    properties: Properties | []Properties
   }
 }
 ```
 
-As with other components, props can be nested here as well. However, it will not work if you have `controls` specified on a parent and child prop both, because that's not possible. And feel free to use [this reference for json5 formatting](https://json5.org), I am sure you will enjoy it.
+As with other components, props can be nested here as well. However, it will not work if you have `controls` specified on a parent and child prop both, because that's not possible.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -89,12 +89,19 @@ As usual, a usage example upfront:
 <KnobsComponent
   knobs={{
     text: {
-      control: 'text',
-      defaultValue: 'http://example.com',
+      control: {
+        type: 'text',
+        value: 'http://example.com'
+      },
       required: true,
     },
-    disabled: { control: 'checkbox' },
-    theme: { control: 'select', options: ['foo', 'bar'] },
+    disabled: {
+      control: { type: 'checkbox' }
+    },
+    theme: {
+      control: { type: 'select' },
+      options: ['foo', 'bar']
+    },
   }}
 />
 ```
@@ -109,9 +116,12 @@ Nested props are supported as well, to infinite depth. For example, a nested `th
 <KnobsComponent
   knobs={{
     theme: {
-      color: { control: 'select', options: ['red', 'blue'] },
+      color: {
+        control: { type: 'select' },
+        options: ['red', 'blue']
+      },
       style: {
-        control: 'select',
+        control: { type: 'select' },
         options: ['primary', 'secondary', 'tertiary'],
       },
     },
@@ -166,18 +176,73 @@ The `props.js` file does have an expected object structure, which is detailed be
 ```typescript
 interface Properties = {
   propName: {
-    type: string, // write out the type you expect however you please
-    description: string, // a short description of your prop
-    required: boolean, // is it a required prop?
-    control: string, // for knobs, see <KnobsComponent> docs above
-    options: []string, // if there are only a specific set of values, detail them here
-    defaultValue: string, // for knobs, the starting value
-    properties: Properties | []Properties
+    type?: string, // write out the type you expect however you please
+    description?: string, // a short description of your prop
+    required?: boolean, // is it a required prop?
+    control?: {, // for knobs, see <KnobsComponent> docs above
+      type: string, // type of control
+      value?: any // starting value for the control
+    },
+    options?: []string, // if there are only a specific set of values allowed, detail them here
+    default?: string, // if there is a default value to this prop
+    testValue?: any, // value to be used as a test fixture, pairs with `fixtureFromProps`
+    properties: Properties | []Properties // if the prop is an array or object with nested items
   }
 }
 ```
 
-As with other components, props can be nested here as well. However, it will not work if you have `controls` specified on a parent and child prop both, because that's not possible.
+As with other components, props can be nested here as well. There are a few specific caveats with the `control` value in nested properties though:
+
+- 
+
+Let's lock this all in with a real example of a simple `props.js` file:
+
+```js
+module.exports = {
+  headline: {
+    type: 'string',
+    description: 'The headline displayed above the content',
+    required: true,
+    testValue: 'Test Headline',
+    control: { type: 'text' }
+  },
+  data: {
+    type: 'object',
+    description: 'data that the component will render',
+    properties: {
+      theme: {
+        type: 'string',
+        description: 'color theme of the rendered data',
+        options: ['dark', 'light'],
+        control: { type: 'text' },
+        default: 'light',
+      },
+      logos: {
+        type: 'array',
+        description: 'company logos to be displayed and show how cool your product is',
+        control: { type: 'json' },
+        properties: [{
+          type: 'string',
+          description: 'a string specifying a known company slug for which the logo will be displayed'
+        }, {
+          type: 'object',
+          description: 'if its not a known company, a custom object containing the necessary info to render',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'the company name'
+            },
+            logo: {
+              type: 'string',
+              description: 'url of the company logo to be displayed'
+            }
+          }
+        }]
+      }
+    }
+  }
+}
+```
 
 ### Options
 

--- a/components-loader.js
+++ b/components-loader.js
@@ -102,7 +102,7 @@ function generateComponentsMetadataFile(components) {
       memo += `  '${component.name}': {
     path: '${component.path}',
     docsPath: '${path.join(component.path, 'docs.mdx')}',
-    propsPath: '${path.join(component.path, 'props.json5')}',
+    propsPath: '${path.join(component.path, 'props.js')}',
     src: ${component.name}
   },
 `

--- a/components/live-component/index.jsx
+++ b/components/live-component/index.jsx
@@ -8,10 +8,11 @@ import { useRestoreUrlState, setUrlState } from '../../utils/url-state'
 import scrollToElement from '../../utils/scroll-to-element'
 
 export default function createLiveComponent(scope) {
-  return function LiveComponent({ children, components }) {
+  return function LiveComponent({ children, components, collapsed = false }) {
     const id = createId(children)
     const componentName = Object.keys(scope)[0]
     const [code, setCode] = useState(children)
+    const [isCollapsed, setIsCollapsed] = useState(collapsed)
 
     // restore saved state if present
     useRestoreUrlState((qs) => {
@@ -39,8 +40,28 @@ export default function createLiveComponent(scope) {
           }}
         >
           <LivePreview />
-          <h6 className={sg.label}>Code Editor</h6>
-          <div className={s.editor}>
+          <h6
+            className={`${sg.label} ${s.clickable}`}
+            onClick={() => setIsCollapsed(!isCollapsed)}
+          >
+            Code Editor
+            <svg
+              width="15"
+              height="10.5"
+              viewBox="0 0 10 7"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className={`${s.caret} ${isCollapsed ? s.caretCollapsed : ''}`}
+            >
+              <path
+                d="M8.05264 2L5.05264 5.00649L2.05264 2"
+                stroke="#aaa"
+                stroke-width="1.25"
+                stroke-linecap="square"
+              ></path>
+            </svg>
+          </h6>
+          <div className={`${s.editor} ${isCollapsed ? s.collapsed : ''}`}>
             <LiveEditor />
           </div>
           <LiveError />

--- a/components/live-component/index.jsx
+++ b/components/live-component/index.jsx
@@ -8,13 +8,13 @@ import { useRestoreUrlState, setUrlState } from '../../utils/url-state'
 import scrollToElement from '../../utils/scroll-to-element'
 
 export default function createLiveComponent(scope) {
-  return function LiveComponent({ children }) {
+  return function LiveComponent({ children, components }) {
     const id = createId(children)
     const componentName = Object.keys(scope)[0]
     const [code, setCode] = useState(children)
 
     // restore saved state if present
-    useRestoreUrlState(qs => {
+    useRestoreUrlState((qs) => {
       if (qs.id == id) {
         setCode(qs.values)
         setTimeout(scrollToElement.bind(null, id), 100)
@@ -31,9 +31,9 @@ export default function createLiveComponent(scope) {
         </div>
         <LiveProvider
           code={code}
-          scope={scope}
+          scope={Object.assign({}, scope, components)}
           theme={theme}
-          transformCode={code => {
+          transformCode={(code) => {
             setCode(code)
             return code
           }}

--- a/components/live-component/style.module.css
+++ b/components/live-component/style.module.css
@@ -3,6 +3,7 @@
   font-family: 'Source Code Pro', monospace;
   font-size: 14px;
   overflow: auto;
+  transition: all 0.25s ease;
 }
 
 .editor * > textarea:focus {
@@ -15,4 +16,23 @@
   padding: 20px;
   margin-bottom: 30px;
   position: relative;
+}
+
+.caret {
+  float: right;
+  margin-right: 5px;
+  transition: all 0.25s ease;
+  transform: rotate(180deg);
+}
+
+.clickable {
+  cursor: pointer;
+}
+
+.collapsed {
+  display: none;
+}
+
+.caretCollapsed {
+  transform: rotate(0deg);
 }

--- a/components/props-table/index.jsx
+++ b/components/props-table/index.jsx
@@ -16,7 +16,6 @@ export default function PropsTable({ props }) {
 }
 
 function renderRows(props, prefixes = []) {
-  // console.log(props)
   const res = []
   if (Array.isArray(props)) {
     props.map((prop) => {

--- a/components/props-table/index.jsx
+++ b/components/props-table/index.jsx
@@ -1,16 +1,6 @@
 import s from './style.module.css'
 import { Fragment } from 'react'
 
-const permittedKeys = [
-  'description',
-  'type',
-  'control',
-  'options',
-  'defaultValue',
-  'required',
-  'itemType',
-]
-
 export default function PropsTable({ props }) {
   return (
     <table className={s.root}>
@@ -25,52 +15,56 @@ export default function PropsTable({ props }) {
   )
 }
 
-function renderRows(props, prefix) {
+function renderRows(props, prefixes = []) {
+  // console.log(props)
   const res = []
-  // let's start by looping through the props object
-  for (let key in props) {
-    const value = props[key]
-
-    // we know which standard keys are expected -- when there are non-standard keys, this is an indication that
-    // we likely have a nested prop
-    const nonStandardKeys = Object.keys(props[key]).filter(
-      (k) => !permittedKeys.includes(k)
-    )
-    const hasNestedProps = !props[key].control && nonStandardKeys.length > 0
-
-    // warn the user if they have included keys in the props object that are non-standard
-    if (props[key].control && nonStandardKeys.length > 0) {
-      console.warn(
-        `The prop object for "${key}" contains non-standard keys: ${JSON.stringify(
-          nonStandardKeys
-        )}. Allowed keys are: ${JSON.stringify(permittedKeys)}`
-      )
-    }
-
-    // render the row given the information
-    res.push(renderRow(key, value, hasNestedProps, prefix))
-
-    // if we have a row that contains nested props, we need to render more rows
-    if (hasNestedProps) {
-      // first let's remove the permitted keys since we already rendered these, to leave only
-      // the top-level nested props
-      const nestedPropsCopy = JSON.parse(JSON.stringify(props[key]))
-      permittedKeys.map((k) => delete nestedPropsCopy[k])
-
-      // now we recurse with the rest of the props
-      res.push(renderRows(nestedPropsCopy, key))
+  if (Array.isArray(props)) {
+    props.map((prop) => {
+      // render the row for the current property
+      res.push(renderRow('[x]', prop, prefixes, true))
+      // render rows for sub-properties if they exist
+      if (prop.properties)
+        res.push(renderRows(prop.properties, [...prefixes, '[x]']))
+    })
+  } else {
+    for (let key in props) {
+      const value = props[key]
+      // figure out whether the property of the current item is an array, and whether it has multiple valid types
+      const arrayPropertyOptions =
+        value.properties && value.properties.length
+          ? value.properties.length > 1
+            ? value.properties.length
+            : 'single'
+          : null
+      // render the row given the information
+      res.push(renderRow(key, value, prefixes, null, arrayPropertyOptions))
+      // render rows for sub-properties if relevant
+      if (value.properties)
+        res.push(renderRows(value.properties, [...prefixes, key]))
     }
   }
-
   return res
 }
 
-function renderRow(key, value, hasNestedProps, prefix) {
+function renderRow(key, value, prefixes, isArray, arrayOptions) {
+  // this bunch of business is to ensure that object syntax chain are separated by periods,
+  // but array syntax are not. like `foo.bar.baz` vs `foo[x].bar`
+  // if the current item is an array syntax, we slice off the trailing period below
+  const prefixSet = prefixes.reduce(
+    (m, p, i) => `${m}${prefixes[i + 1]?.charAt(0) === '[' ? p : p + '.'}`,
+    ''
+  )
   return (
     <tr key={key}>
       <td>
         <code>
-          {prefix ? <span className={s.prefix}>{prefix}.</span> : ''}
+          {prefixes.length ? (
+            <span className={s.prefix}>
+              {isArray ? prefixSet.slice(0, -1) : prefixSet}
+            </span>
+          ) : (
+            ''
+          )}
           {key}
           {value.required ? <span className={s.required}>*</span> : ''}
           <div className={s.type}>{value.type}</div>
@@ -95,12 +89,20 @@ function renderRow(key, value, hasNestedProps, prefix) {
             <code>{value.itemType}</code>
           </div>
         )}
-        {hasNestedProps && (
+        {value.properties && (
           <div className={s.containsNested}>
-            Contains nested props, see below:
+            {renderHelperText(arrayOptions)}
           </div>
         )}
       </td>
     </tr>
   )
+}
+
+function renderHelperText(arrayOptions) {
+  if (typeof arrayOptions === 'number')
+    return `Array can contain any of the ${arrayOptions} types below:`
+  if (arrayOptions === 'single')
+    return 'Array members must be of the type below:'
+  return 'Object contains nested props, see below:'
 }

--- a/components/shared.module.css
+++ b/components/shared.module.css
@@ -6,6 +6,7 @@
   letter-spacing: 1px;
   border-bottom: 1px solid #eee;
   padding-bottom: 2px;
+  overflow: hidden;
 }
 
 .save {

--- a/components/shared.module.css
+++ b/components/shared.module.css
@@ -24,6 +24,7 @@
   opacity: 0.5;
   cursor: pointer;
   transition: opacity 0.25s ease;
+  z-index: 9999;
 }
 
 .save:hover {

--- a/example/components/button/docs.mdx
+++ b/example/components/button/docs.mdx
@@ -4,7 +4,9 @@ componentName: 'Button'
 
 This is the docs for the button component
 
-<LiveComponent>{`<Button text='this is a button' />`}</LiveComponent>
+<LiveComponent
+  components={{ Test: () => <p>test successful</p> }}
+>{`<><Button text='this is a button' /><Test /></>`}</LiveComponent>
 
 <PropsTable props={componentProps} />
 

--- a/example/components/button/docs.mdx
+++ b/example/components/button/docs.mdx
@@ -6,8 +6,6 @@ This is the docs for the button component
 
 <LiveComponent>{`<Button text='this is a button' />`}</LiveComponent>
 
-<KnobsComponent knobs={componentProps} />
-
 <PropsTable props={componentProps} />
 
 <Tester />

--- a/example/components/button/docs.mdx
+++ b/example/components/button/docs.mdx
@@ -4,9 +4,10 @@ componentName: 'Button'
 
 This is the docs for the button component
 
-<LiveComponent
-  components={{ Test: () => <p>test successful</p> }}
->{`<><Button text='this is a button' /><Test /></>`}</LiveComponent>
+<LiveComponent components={{ Test: () => <p>test successful</p> }}>{`<>
+  <Button text='this is a button' />
+  <Test />
+</>`}</LiveComponent>
 
 <PropsTable props={componentProps} />
 

--- a/example/components/button/index.jsx
+++ b/example/components/button/index.jsx
@@ -1,5 +1,9 @@
 import s from './style.module.css'
 
-export default function Button({ text }) {
-  return <button className={s.root}>{text}</button>
+export default function Button({ text, testObject }) {
+  return (
+    <button className={s.root}>
+      {text}, {JSON.stringify(testObject)}
+    </button>
+  )
 }

--- a/example/components/button/props.js
+++ b/example/components/button/props.js
@@ -1,0 +1,48 @@
+module.exports = {
+  text: {
+    control: 'text',
+    type: 'string',
+    defaultValue: 'button text',
+    description: 'the text displayed by the button',
+  },
+  testObject: {
+    type: 'object',
+    description: 'test description yay',
+    properties: {
+      foo: {
+        type: 'object',
+        description: 'test description',
+        properties: {
+          bar: {
+            type: 'string',
+            description: 'deep nested yeahh',
+          },
+        },
+      },
+      baz: {
+        type: 'array',
+        description: 'a test array, nice',
+        properties: [
+          { type: 'string', description: 'any string value' },
+          {
+            type: 'object',
+            description: 'an object value',
+            properties: {
+              quux: { type: 'string', description: 'object in an array' },
+            },
+          },
+        ],
+      },
+    },
+  },
+  testObj2: {
+    type: 'array',
+    description: 'test obj with monotype array',
+    properties: [
+      {
+        type: 'string',
+        description: 'only a string is allowed',
+      },
+    ],
+  },
+}

--- a/example/components/button/props.json5
+++ b/example/components/button/props.json5
@@ -1,8 +1,0 @@
-{
-  text: {
-    control: 'text',
-    type: 'string',
-    defaultValue: 'button text',
-    description: 'the text displayed by the button',
-  },
-}

--- a/getStaticProps.js
+++ b/getStaticProps.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import matter from 'gray-matter'
 import { existsSync } from 'fsexists'
-import json5 from 'json5'
+import requireFromString from 'require-from-string'
 import renderToString from 'next-mdx-remote/render-to-string'
 import createScope from './utils/create-scope'
 import components from './__octavo_components'
@@ -41,7 +41,7 @@ export default function createStaticProps(octavoOptions = {}) {
         // our component and some additional presentational components that are made available in the mdx file.
         return renderToString(content, {
           components: createScope({ [name]: Component }, octavoOptions),
-          scope: props && { componentProps: json5.parse(props) },
+          scope: props && { componentProps: requireFromString(props) },
         }).then((res) => [name, res])
         // transform to an object for easier name/component mapping on the client side
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -7374,6 +7374,11 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "fsexists": "^1.0.1",
     "globby": "^11.0.1",
     "gray-matter": "^4.0.2",
-    "json5": "^2.1.3",
     "loader-utils": "^2.0.0",
     "next-mdx-remote": "1.0.0",
     "query-string": "^5.1.1",
-    "react-live": "^2.2.2"
+    "react-live": "^2.2.2",
+    "require-from-string": "^2.0.2"
   },
   "devDependencies": {
     "jest": "^26.4.2",

--- a/page.jsx
+++ b/page.jsx
@@ -10,9 +10,16 @@ export default function createPage(octavoOptions = {}) {
   return function Page({ mdxSources, componentNames }) {
     // tracks the name of the current component
     const [name, setName] = useState(componentNames[0])
+    const [componentNotFound, setComponentNotFound] = useState(false)
 
     // if there's a component specified in the querystring, set that to current
-    useRestoreUrlState(({ component }) => component && setName(component))
+    useRestoreUrlState(({ component }) => {
+      if (component && components[component]) {
+        setName(component)
+      } else {
+        setComponentNotFound(component)
+      }
+    })
 
     // finds the actual component
     const Component = components[name].src
@@ -44,7 +51,14 @@ export default function createPage(octavoOptions = {}) {
             )
           })}
         </ul>
-        <div className={s.stage}>{mdx}</div>
+        <div className={s.stage}>
+          {componentNotFound && (
+            <p className={s.notFound}>
+              ⚠️ Component "{componentNotFound}" was not found
+            </p>
+          )}
+          {mdx}
+        </div>
       </div>
     )
   }

--- a/style.module.css
+++ b/style.module.css
@@ -65,6 +65,13 @@
   background-repeat: no-repeat;
 }
 
+.notFound {
+  background: #df7873;
+  padding: 12px 17px;
+  color: white;
+  border-radius: 5px;
+}
+
 .stage {
   padding: 20px 30px 30px;
   float: left;


### PR DESCRIPTION
A couple goals with this PR:

- Make deeply nested properties document-able, including a mix of arrays and objects
- Clean up and improve the prop names to make things more clear

This is a very breaking change, specific API breakages notes below:
- `props.json5` is now `props.js`
- nested properties now must be placed under a `properties` key rather than being directly nested - this key can take either an array of object depending on the nested value type, and can be deep nested indefinitely
- `defaultValue` is now named `testValue`, and can accept any normal javascript data structure
- `itemType` is now deprecated, as arrays can be provided to the `properties` key at any level and documented by individual type
- a new optional key, `default` has been added to specify when a property has a value it is set to by default
- `control` now becomes an object rather than a string, the previous string value should be under a `type` key. So for example `control: 'select'` is now `control: { type: 'select' }`. Also, a `value` can be passed in which sets the initial control value

And a variety of small improvements and additions were added here as well:
- When the querystring path specifies a component that can't be found, the error is graceful rather than awful error
- `LiveComponent` now can take a `components` prop, which can be used to pass in locally available components within the block, and a `collapse` prop, which will collapse the block by default when set to `true`.